### PR TITLE
改进暗色主题下的标题栏显示效果

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -9,6 +9,7 @@
   align-items: center;
   border-bottom: #e4e4e4 1px solid;
   flex-wrap: wrap;
+  background-color: var(--background-primary);
 }
 
 .copy-button {


### PR DESCRIPTION
默认情况下，在暗色的主题中，标题栏的白色底色会导致文字难以看清：
![image](https://github.com/sunbooshi/note-to-mp/assets/4013062/dbe17ef2-c755-486d-8e72-d9c50048b92f)


在 css 里使用 background-primary 变量之后，就可以应用和主题一致的背景色：
![image](https://github.com/sunbooshi/note-to-mp/assets/4013062/0a9f905a-d3c3-4720-94fb-53b3cc210f2e)
