### PR TITLE
[improvement] compatible with wechat article platform ul/ol indent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,16 +26,6 @@
 				"typescript": "4.7.4"
 			}
 		},
-		"node_modules/@aashutoshrathi/word-wrap": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-			"integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@codemirror/state": {
 			"version": "6.4.1",
 			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.1.tgz",
@@ -44,9 +34,9 @@
 			"peer": true
 		},
 		"node_modules/@codemirror/view": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.26.0.tgz",
-			"integrity": "sha512-nSSmzONpqsNzshPOxiKhK203R6BvABepugAe34QfQDbNDslyjkqBuKgrK5ZBvqNXpfxz5iLrlGTmEfhbQyH46A==",
+			"version": "6.33.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.33.0.tgz",
+			"integrity": "sha512-AroaR3BvnjRW8fiZBalAaK+ZzB5usGgI014YKElYZvQdNH5ZIidHlO+cyf/2rWzyBFRkvG6VhiXeAEbC53P2YQ==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -424,9 +414,9 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.10.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
-			"integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
+			"integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
 			"dev": true,
 			"peer": true,
 			"engines": {
@@ -471,6 +461,7 @@
 			"version": "0.11.14",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
 			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+			"deprecated": "Use @eslint/config-array instead",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -497,9 +488,10 @@
 			}
 		},
 		"node_modules/@humanwhocodes/object-schema": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
-			"integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+			"deprecated": "Use @eslint/object-schema instead",
 			"dev": true,
 			"peer": true
 		},
@@ -560,9 +552,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "16.18.89",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.89.tgz",
-			"integrity": "sha512-QlrE8QI5z62nfnkiUZysUsAaxWaTMoGqFVcB3PvK1WxJ0c699bacErV4Fabe9Hki6ZnaHalgzihLbTl2d34XfQ==",
+			"version": "16.18.108",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.108.tgz",
+			"integrity": "sha512-fj42LD82fSv6yN9C6Q4dzS+hujHj+pTv0IpRR3kI20fnYeS0ytBpjFO9OjmDowSPPt4lNKN46JLaKbCyP+BW2A==",
 			"dev": true
 		},
 		"node_modules/@types/tern": {
@@ -766,9 +758,9 @@
 			"peer": true
 		},
 		"node_modules/@zip.js/zip.js": {
-			"version": "2.7.43",
-			"resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.43.tgz",
-			"integrity": "sha512-kW7elA/Q1o5xusStfZeysCvheD1SvW3TWDfqTCmoWW4ALBSqKonZSTrQgdEGOUec2U/TLMSGq0SuSMTAxy4gFg==",
+			"version": "2.7.52",
+			"resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.52.tgz",
+			"integrity": "sha512-+5g7FQswvrCHwYKNMd/KFxZSObctLSsQOgqBSi0LzwHo3li9Eh1w5cF5ndjQw9Zbr3ajVnd2+XyiX85gAetx1Q==",
 			"engines": {
 				"bun": ">=0.7.0",
 				"deno": ">=1.0.0",
@@ -776,9 +768,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.11.3",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+			"version": "8.12.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
 			"dev": true,
 			"peer": true,
 			"bin": {
@@ -876,12 +868,12 @@
 			}
 		},
 		"node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
 			"dependencies": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -969,12 +961,12 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
 			"dev": true,
 			"dependencies": {
-				"ms": "2.1.2"
+				"ms": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=6.0"
@@ -1221,9 +1213,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
-			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -1355,9 +1347,9 @@
 			}
 		},
 		"node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -1422,6 +1414,7 @@
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -1506,22 +1499,22 @@
 			}
 		},
 		"node_modules/highlight.js": {
-			"version": "11.9.0",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
-			"integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==",
+			"version": "11.10.0",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.10.0.tgz",
+			"integrity": "sha512-SYVnVFswQER+zu1laSya563s+F8VDGt7o35d4utbamowvUNLLMovFqwCLSocpZTz3MgaSRA1IbqRWZv97dtErQ==",
 			"engines": {
 				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/html-to-image": {
 			"version": "1.11.11",
-			"resolved": "https://registry.npmmirror.com/html-to-image/-/html-to-image-1.11.11.tgz",
+			"resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
 			"integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA=="
 		},
 		"node_modules/ignore": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"dev": true,
 			"engines": {
 				"node": ">= 4"
@@ -1558,6 +1551,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -1700,22 +1694,10 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/marked": {
-			"version": "12.0.1",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-12.0.1.tgz",
-			"integrity": "sha512-Y1/V2yafOcOdWQCX0XpAKXzDakPOpn6U0YLxTJs3cww6VxOzZV1BTOOYWLvH3gX38cq+iLwljHHTnMtlDfg01Q==",
+			"version": "12.0.2",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+			"integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -1724,11 +1706,11 @@
 			}
 		},
 		"node_modules/marked-highlight": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/marked-highlight/-/marked-highlight-2.1.3.tgz",
-			"integrity": "sha512-t35JWm2u8HanOJ+gSJBAYQ0Jgr3vy+gl7ORAXN8bSEQFHl5FYXH0A7YXVMrfhmKaSuBSy6LidXECn3U9Qv/dHA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/marked-highlight/-/marked-highlight-2.1.4.tgz",
+			"integrity": "sha512-D1GOkcdzP+1dzjoColL7umojefFrASDuLeyaHS0Zr/Uo9jkr1V6vpLRCzfi1djmEaWyK0SYMFtHnpkZ+cwFT1w==",
 			"peerDependencies": {
-				"marked": ">=4 <14"
+				"marked": ">=4 <15"
 			}
 		},
 		"node_modules/merge2": {
@@ -1741,12 +1723,12 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
 			"dependencies": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			},
 			"engines": {
@@ -1776,9 +1758,9 @@
 			}
 		},
 		"node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true
 		},
 		"node_modules/natural-compare": {
@@ -1789,9 +1771,9 @@
 			"peer": true
 		},
 		"node_modules/obsidian": {
-			"version": "1.5.7-1",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.5.7-1.tgz",
-			"integrity": "sha512-T5ZRuQ1FnfXqEoakTTHVDYvzUEEoT8zSPnQCW31PVgYwG4D4tZCQfKHN2hTz1ifnCe8upvwa6mBTAP2WUA5Vng==",
+			"version": "1.6.6",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.6.6.tgz",
+			"integrity": "sha512-GZHzeOiwmw/wBjB5JwrsxAZBLqxGQmqtEKSvJJvT0LtTcqeOFnV8jv0ZK5kO7hBb44WxJc+LdS7mZgLXbb+qXQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/codemirror": "5.60.8",
@@ -1813,18 +1795,18 @@
 			}
 		},
 		"node_modules/optionator": {
-			"version": "0.9.3",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
-			"integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@aashutoshrathi/word-wrap": "^1.2.3",
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
 				"levn": "^0.4.1",
 				"prelude-ls": "^1.2.1",
-				"type-check": "^0.4.0"
+				"type-check": "^0.4.0",
+				"word-wrap": "^1.2.5"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
@@ -2002,6 +1984,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -2038,13 +2021,10 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -2248,18 +2228,22 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/word-wrap": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true,
 			"peer": true
-		},
-		"node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",

--- a/src/markdown/link.ts
+++ b/src/markdown/link.ts
@@ -36,7 +36,7 @@ export class LinkRenderer extends Extension {
         }
         
         const links = this.allLinks.map((href, i) => {
-            return `<li>${href}&nbsp;↩</li>`;
+            return `<li>${href}</li>`;
         });
         return `${html}<seciton class="footnotes"><hr><ol>${links.join('')}</ol></section>`;
     }

--- a/themes/mweb-ayu-mirage.css
+++ b/themes/mweb-ayu-mirage.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: rgb(254, 203, 102);
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-ayu.css
+++ b/themes/mweb-ayu.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: rgb(255, 106, 0);
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-bear-default.css
+++ b/themes/mweb-bear-default.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: #353535;
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-charcoal.css
+++ b/themes/mweb-charcoal.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: rgb(155, 183, 196);
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-cobalt.css
+++ b/themes/mweb-cobalt.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: rgb(252, 133, 30);
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-contrast.css
+++ b/themes/mweb-contrast.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: #2478c5;
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-d-boring.css
+++ b/themes/mweb-d-boring.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: rgb(127, 127, 127);
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-dark-graphite.css
+++ b/themes/mweb-dark-graphite.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: rgb(74, 168, 251);
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-dieci.css
+++ b/themes/mweb-dieci.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: rgb(242, 148, 41);
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-dracula.css
+++ b/themes/mweb-dracula.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: rgb(205, 174, 249);
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-duotone-heat.css
+++ b/themes/mweb-duotone-heat.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: rgb(202, 124, 208);
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-duotone-light.css
+++ b/themes/mweb-duotone-light.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: rgb(115, 144, 201);
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-gandalf.css
+++ b/themes/mweb-gandalf.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: rgb(160, 76, 107);
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-gotham.css
+++ b/themes/mweb-gotham.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: rgb(42, 168, 137);
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-lighthouse.css
+++ b/themes/mweb-lighthouse.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: rgb(209, 95, 38);
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-nord.css
+++ b/themes/mweb-nord.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: rgb(144, 185, 201);
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-olive-dunk.css
+++ b/themes/mweb-olive-dunk.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: rgb(149, 175, 163);
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-panic.css
+++ b/themes/mweb-panic.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: rgb(249, 181, 55);
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-red-graphite.css
+++ b/themes/mweb-red-graphite.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: #e06e73;
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-smartblue.css
+++ b/themes/mweb-smartblue.css
@@ -62,7 +62,7 @@
 }
 .note-to-mp ul {
   list-style: disc outside;
-  margin-left: 2em;
+  padding-left: 2em;
   margin-top: 1em;
 }
 .note-to-mp li {

--- a/themes/mweb-solarized-dark.css
+++ b/themes/mweb-solarized-dark.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: rgb(44, 146, 133);
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-solarized-light.css
+++ b/themes/mweb-solarized-light.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: rgb(165, 104, 18);
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {

--- a/themes/mweb-toothpaste.css
+++ b/themes/mweb-toothpaste.css
@@ -125,8 +125,7 @@
   word-wrap: break-all;
 }
 .note-to-mp ul {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
 }
 .note-to-mp li::marker {
   color: rgb(199, 191, 127);
@@ -135,8 +134,7 @@
   margin: 0;
 }
 .note-to-mp ol {
-  margin-left: 1.3em;
-  padding: 0;
+  padding-left: 1.3em;
   list-style-type: decimal;
 }
 .note-to-mp .task-list-item {


### PR DESCRIPTION
In the wechat article platform, the `ul/ol` has a global `padding-left-x` class which decides the unified indents.

So, we should use `padding` instead of `margin`, which achieves the same effect, but o.w. causing the problem of unexpected mixed indents.